### PR TITLE
Chunked msg reading

### DIFF
--- a/src/__tests__/peer-socket-reading.ts
+++ b/src/__tests__/peer-socket-reading.ts
@@ -1,0 +1,193 @@
+import * as net from 'node:net';
+import { PeerDirection, StacksPeer } from '../peer-handler';
+import { Preamble } from '../message/preamble';
+import { BurnchainHeaderHash } from '../message/burnchain-header-hash';
+import { MessageSignature } from '../message/message-signature';
+import { NeighborAddress } from '../message/neighbor-address';
+import { PeerAddress } from '../message/peer-address';
+import { RelayDataVec } from '../message/relay-data';
+import { Handshake } from '../message/handshake';
+import { StacksMessageEnvelope } from '../message/stacks-message-envelope';
+import { ResizableByteStream } from '../resizable-byte-stream';
+
+function createTestHandshakeMessage() {
+  const preamble = new Preamble(
+    123,
+    321,
+    4,
+    5n,
+    new BurnchainHeaderHash('ff'.repeat(32)),
+    6n,
+    new BurnchainHeaderHash('ee'.repeat(32)),
+    7,
+    new MessageSignature('dd'.repeat(65)),
+    8
+  );
+  const neighborAddress = new NeighborAddress(
+    new PeerAddress('0f'.repeat(16)),
+    4000,
+    '0e'.repeat(20)
+  );
+  const relayVec = new RelayDataVec([]);
+  const handshake = new Handshake(
+    new PeerAddress('0d'.repeat(16)),
+    5000,
+    0,
+    '0c'.repeat(33),
+    50n,
+    'http://test.local'
+  );
+  const envelope = new StacksMessageEnvelope(preamble, relayVec, handshake);
+  const privKey = Buffer.from(
+    '8c45db8322f3f8e36389bc4e6091e82060ed2d0db7d8ac6858cc3e90a6639715',
+    'hex'
+  );
+  envelope.sign(privKey);
+  return envelope;
+}
+
+async function createTestSocket() {
+  const server = net.createServer().unref();
+  await new Promise<void>((resolve, reject) => {
+    server.on('error', reject);
+    server.listen({ host: 'localhost', port: 0 }, resolve);
+  });
+  const port = (server.address() as net.AddressInfo).port;
+
+  const [readerSocket, writerSocket] = await new Promise<
+    [net.Socket, net.Socket]
+  >((resolve, reject) => {
+    server.on('connection', (reader) => resolve([reader.unref(), writer]));
+    const writer = net
+      .createConnection({ host: 'localhost', port })
+      .on('error', reject)
+      .unref();
+  });
+  return { server, readerSocket, writerSocket };
+}
+
+async function writeSocketFlushed(socket: net.Socket, data: Buffer) {
+  const flushed = await new Promise((resolve, reject) => {
+    const flushed = socket.write(data, (err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(flushed);
+      }
+    });
+  });
+  if (!flushed) {
+    await new Promise((resolve) => {
+      socket.once('drain', resolve);
+    });
+  }
+}
+
+describe('peer socket reading', () => {
+  it('should read exactly one message sent at a time', async () => {
+    const { server, readerSocket, writerSocket } = await createTestSocket();
+    const peer = new StacksPeer(readerSocket, PeerDirection.Inbound);
+
+    const msg = createTestHandshakeMessage();
+    const msgByteStream = new ResizableByteStream();
+    msg.encode(msgByteStream);
+    msgByteStream.seek(0);
+    const msgBuffer = msgByteStream.readBytesAsBufferCopied(
+      msgByteStream.byteLength
+    );
+
+    // Write 3 messages to the socket, each in a separate write call that contains the whole message in one chunk
+    for (let i = 0; i < 3; i++) {
+      // write to writerSocket and ensure data is flushed
+      await writeSocketFlushed(writerSocket, msgBuffer);
+      // read from peer and ensure message is received
+      const recvMsg = await new Promise((resolve) => {
+        peer.once('messageReceived', resolve);
+      });
+      expect(recvMsg).toEqual(msg);
+    }
+
+    writerSocket.destroy();
+    readerSocket.destroy();
+    server.close();
+  });
+
+  it('should ready multiple messages sent in one chunk', async () => {
+    const { server, readerSocket, writerSocket } = await createTestSocket();
+    const peer = new StacksPeer(readerSocket, PeerDirection.Inbound);
+
+    const msg = createTestHandshakeMessage();
+    const msgByteStream = new ResizableByteStream();
+    // write 3 messages to the byte stream
+    for (let i = 0; i < 3; i++) {
+      msg.encode(msgByteStream);
+    }
+    msgByteStream.seek(0);
+    const msgBuffer = msgByteStream.readBytesAsBufferCopied(
+      msgByteStream.byteLength
+    );
+
+    // write chunk containing multiple message to writerSocket and ensure data is flushed
+    await writeSocketFlushed(writerSocket, msgBuffer);
+    let chunksRead = 0;
+    readerSocket.on('data', (data) => {
+      chunksRead++;
+    });
+
+    // ensure peer reads all 3 messages
+    const msgs = await new Promise((resolve) => {
+      const msgs: StacksMessageEnvelope[] = [];
+      peer.on('messageReceived', (msg) => {
+        msgs.push(msg);
+        if (msgs.length === 3) {
+          resolve(msgs);
+        }
+      });
+    });
+    expect(msgs).toEqual([msg, msg, msg]);
+    expect(chunksRead).toBe(1);
+    writerSocket.destroy();
+    readerSocket.destroy();
+    server.close();
+  });
+
+  it('should read a message that is sent in multiple chunks', async () => {
+    const { server, readerSocket, writerSocket } = await createTestSocket();
+    writerSocket.setNoDelay(true);
+
+    const peer = new StacksPeer(readerSocket, PeerDirection.Inbound);
+
+    const msg = createTestHandshakeMessage();
+    const msgByteStream = new ResizableByteStream();
+    msg.encode(msgByteStream);
+    msgByteStream.seek(0);
+    const msgBuffer = msgByteStream.readBytesAsBufferCopied(
+      msgByteStream.byteLength
+    );
+
+    // Break the message up into 3 chunks and write each chunk to writerSocket.
+    // First chunk doesn't have the full preamble so it should be cached until the next chunk is received
+    const chunk1 = msgBuffer.subarray(0, 10);
+    // second chunk has the full preamble so at least the fully payload size should be known
+    const chunk2 = msgBuffer.subarray(10, Preamble.BYTE_SIZE);
+    // third chunk has the full payload so the message should be fully readable
+    const chunk3 = msgBuffer.subarray(Preamble.BYTE_SIZE);
+
+    // write each chunk, and ensure data is read in chunks
+    await writeSocketFlushed(writerSocket, chunk1);
+    await new Promise((resolve) => readerSocket.once('data', resolve));
+    await writeSocketFlushed(writerSocket, chunk2);
+    await new Promise((resolve) => readerSocket.once('data', resolve));
+    await writeSocketFlushed(writerSocket, chunk3);
+
+    // read from peer and ensure message is received
+    const recvMsg = await new Promise((resolve) => {
+      peer.once('messageReceived', resolve);
+    });
+    expect(recvMsg).toEqual(msg);
+
+    writerSocket.destroy();
+    readerSocket.destroy();
+    server.close();
+  });
+});

--- a/src/message/preamble.ts
+++ b/src/message/preamble.ts
@@ -1,9 +1,11 @@
-import { ResizableByteStream } from '../resizable-byte-stream';
+import { INT_SIZE, ResizableByteStream } from '../resizable-byte-stream';
 import { Encodeable } from '../stacks-p2p-deser';
 import { MessageSignature } from './message-signature';
 import { BurnchainHeaderHash } from './burnchain-header-hash';
 
 export class Preamble implements Encodeable {
+  static readonly BYTE_SIZE = 165;
+
   /**
    * (u32)
    * A 4-byte scalar to encode the semantic version of this software.
@@ -113,5 +115,15 @@ export class Preamble implements Encodeable {
     target.writeUint32(this.additional_data);
     this.signature.encode(target);
     target.writeUint32(this.payload_len);
+  }
+
+  /** Read only the `payload_len` value out of a byte aray that encodes a Preamble */
+  static readPayloadLength(buffer: Uint8Array): number {
+    const view = new DataView(
+      buffer.buffer,
+      buffer.byteOffset,
+      buffer.byteLength
+    );
+    return view.getUint32(this.BYTE_SIZE - INT_SIZE.I32);
   }
 }

--- a/src/p2p-control-plane-server.ts
+++ b/src/p2p-control-plane-server.ts
@@ -42,5 +42,8 @@ export async function startControlPlaneServer() {
 function handleNewInboundSocket(socket: net.Socket) {
   const socketAddr = `${socket.remoteAddress}:${socket.remotePort}`;
   logger.info(`New control-plane inbound socket connection from ${socketAddr}`);
-  new StacksPeer(socket, PeerDirection.Inbound);
+  const peer = new StacksPeer(socket, PeerDirection.Inbound);
+  peer.initHandshake().catch((error) => {
+    logger.error(error, 'Error initializing handshake');
+  });
 }

--- a/src/peer-handler.ts
+++ b/src/peer-handler.ts
@@ -79,6 +79,7 @@ interface StacksPeerEvents {
   closed: (error?: Error) => void | Promise<void>;
   socketError: (error: Error) => void | Promise<void>;
   open: () => void | Promise<void>;
+  messageReceived: (message: StacksMessageEnvelope) => void | Promise<void>;
 }
 
 export class StacksPeer extends EventEmitter {
@@ -106,11 +107,6 @@ export class StacksPeer extends EventEmitter {
     this.socket = socket;
     this.listen();
     peerConnections.register(this);
-
-    // TODO: should this be called in the constructor? might be better for caller to invoke this
-    this.initHandshake().catch((error) => {
-      logger.error(error, 'Error initializing handshake');
-    });
   }
 
   on<T extends keyof StacksPeerEvents>(
@@ -118,6 +114,13 @@ export class StacksPeer extends EventEmitter {
     listener: StacksPeerEvents[T]
   ): this {
     return super.on(eventName, listener);
+  }
+
+  once<T extends keyof StacksPeerEvents>(
+    eventName: T,
+    listener: StacksPeerEvents[T]
+  ): this {
+    return super.once(eventName, listener);
   }
 
   emit<T extends keyof StacksPeerEvents>(
@@ -128,13 +131,7 @@ export class StacksPeer extends EventEmitter {
   }
 
   private listen() {
-    this.socket.on('data', (data) => {
-      const byteStream = new ResizableByteStream();
-      byteStream.writeBytes(data);
-      byteStream.seek(0);
-      const receivedMsg = StacksMessageEnvelope.decode(byteStream);
-      logger.debug(receivedMsg, 'got peer message');
-    });
+    this.setupDataReader();
     this.socket.on('error', (err) => {
       logger.error(err, 'Error on peer socket');
       this.emit('socketError', err);
@@ -149,7 +146,61 @@ export class StacksPeer extends EventEmitter {
     });
   }
 
-  private async initHandshake() {
+  private setupDataReader() {
+    // the left over data from the last received chunk
+    let lastChunk = Buffer.alloc(0);
+
+    const handleRecvData = (data: Buffer) => {
+      // Read in chunks to get first the preamble (fixed size),
+      // then get the payload size from the preamble and read that.
+      // Then write any extra bytes into a new byte stream.
+      const buff =
+        lastChunk.length === 0 ? data : Buffer.concat([lastChunk, data]);
+
+      if (buff.length < Preamble.BYTE_SIZE) {
+        // not enough data yet to read a message, save the chunk and wait for more
+        lastChunk = buff;
+        return;
+      }
+
+      const payloadLength = Preamble.readPayloadLength(buff);
+      if (buff.length < payloadLength + Preamble.BYTE_SIZE) {
+        // not enough data yet to read a message, save the chunk and wait for more
+        lastChunk = buff;
+        return;
+      }
+
+      // we have enough data to read a message, decode into a StacksMessageEnvelope
+      const byteStream = new ResizableByteStream();
+      byteStream.writeBytes(buff);
+      byteStream.seek(0);
+      const receivedMsg = StacksMessageEnvelope.decode(byteStream);
+
+      if (buff.length > byteStream.position) {
+        // extra data left over after reading the message, save it for next time
+        lastChunk = byteStream.readBytesAsBuffer(
+          byteStream.byteLength - byteStream.position
+        );
+      } else {
+        // no extra data left over
+        lastChunk = Buffer.alloc(0);
+      }
+
+      logger.debug(receivedMsg, 'got peer message');
+      this.emit('messageReceived', receivedMsg);
+
+      if (lastChunk.length > 0) {
+        // if there's more data, recursively handle it
+        handleRecvData(Buffer.alloc(0));
+      }
+    };
+
+    this.socket.on('data', (data) => {
+      handleRecvData(data);
+    });
+  }
+
+  async initHandshake() {
     let peerVersion: number;
     let networkID: number;
     let stableConfirmations: number;
@@ -250,6 +301,9 @@ export class StacksPeer extends EventEmitter {
     });
     const peer = new this(socket, PeerDirection.Outbound);
     logger.info(`Connected to Stacks peer: ${peer.address}`);
+    peer.initHandshake().catch((error) => {
+      logger.error(error, 'Error initializing handshake');
+    });
     return peer;
   }
 }


### PR DESCRIPTION
Updates tcp socket reading so that it can read chunks that contain only partial messages, and read chunks that contain multiple messages. Uses the fixed-size preamble's payload size logic defined in SIP-003.